### PR TITLE
Minimize Teams window on blur + extension options

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,6 +13,14 @@
       "matches": ["https://teams.microsoft.com/*", "http://localhost/*"]
     }
   ],
+  "background": {
+    "service_worker": "scripts/service-worker.js"
+  },
+  "permissions": [
+    "tabs",
+    "storage"
+  ],
+  "options_page": "options/options.html",
   "web_accessible_resources": [
     {
       "resources": [

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Microsoft Teams Notification Sound Extension Options</title>
+
+  <style>
+    .description {
+      color: gray;
+      font-size: smaller;
+    }
+
+    #saveButton {
+      margin-top: 1rem;
+    }
+
+    .checkbox-option {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+
+    .checkbox-option>div:first-child {
+      margin-right: .5rem;
+    }
+
+    #statusMessage {
+      display: inline;
+      margin-top: 1rem;
+      margin-left: 1rem;
+    }
+
+    button {
+      font-size: large;
+      padding: .25em .5em;
+    }
+  </style>
+</head>
+
+<body>
+
+  <h1>Microsoft Teams Notification Sound - options</h1>
+
+  <div class="checkbox-option">
+    <div>
+      <input id="minimizeWindow" type="checkbox" value="1">
+    </div>
+    <div>
+      <label for="minimizeWindow">
+        Minimize Teams window if not active
+        <div class="description">If not minimized, Teams doesn't send notifications for current (selected) chat. If
+          checked, the Teams window will be minimized only if it contains no other tab.</div>
+      </label>
+    </div>
+  </div>
+
+  <button id="saveButton">Save</button>
+
+  <div id="statusMessage"></div>
+
+  <script src="options.js"></script>
+</body>
+
+</html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,33 @@
+// Saves options to chrome.storage
+function saveOptions() {
+  var minimizeWindow = document.getElementById('minimizeWindow').checked;
+
+  const options = {
+    minimizeWindow: minimizeWindow
+  };
+
+  console.debug('Options to be saved', options);
+
+  chrome.storage.sync.set(options, () => {
+    console.debug('Options saved');
+    var status = document.getElementById('statusMessage');
+    status.textContent = 'Options saved';
+    setTimeout(() => { status.textContent = '' }, 1000);
+  });
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restoreOptions() {
+  // Use default value for minimizeWindow
+  chrome.storage.sync.get(
+    { minimizeWindow: true },
+    options => {
+      console.debug('Options from storage or defaults', options);
+      document.getElementById('minimizeWindow').checked = Boolean(options.minimizeWindow);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('saveButton')
+  .addEventListener('click', saveOptions);

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -5,3 +5,27 @@ s.onload = function () {
   this.remove();
 };
 (document.head || document.documentElement).appendChild(s);
+
+const createFocusLossHandler = windowId => { 
+  return () => {
+    if (!document.hasFocus()) {
+      console.debug('Trying to minimize current window. Origin: ' + windowId);
+      chrome.runtime.sendMessage(
+        {
+          action: 'minimizeCurrentWindow'
+        },
+        () => console.debug('Window minimized - confirmed'));
+    }
+  };
+};
+
+window.addEventListener('blur', createFocusLossHandler('main-window'));
+
+// The main window doesn't fire blur event if the focus was in an iframe. So add listeners to iframes as well.
+window.addEventListener('load', () => {
+  console.debug('Searching for iframes');
+  document.querySelectorAll('iframe').forEach(docIframe => {
+    console.debug('Adding blur listener for iframe', docIframe.src);
+    docIframe.contentWindow.addEventListener('blur', createFocusLossHandler('iframe#' + docIframe.id));
+  })
+});

--- a/src/scripts/service-worker.js
+++ b/src/scripts/service-worker.js
@@ -1,0 +1,30 @@
+let defaultOptions = {
+  minimizeWindow: true
+};
+
+const minimizeCurrentWindowListener = (request, sender, sendResponse) => {
+  console.debug('Message received: ' + request.action);
+  if (request && request.action === 'minimizeCurrentWindow') {
+    chrome.storage.sync.get(defaultOptions, extensionOptions => {
+      if (extensionOptions.minimizeWindow) {
+        chrome.windows.get(sender.tab.windowId, { populate: true }).then(senderWindow => {
+          if (senderWindow.tabs.length === 1) {
+            console.debug('Trying to minimize current window: ' + sender.tab.windowId);
+            chrome.windows.update(senderWindow.id, { state: 'minimized' })
+            .then(() => {
+              console.debug('Window ' + senderWindow.id + ' minimized');
+              sendResponse();
+            });
+          } else {
+            console.debug('Current window has ' + senderWindow.tabs.length + ' - it will not be minimized');
+          }
+        });
+      } else {
+        console.debug('Minimizing Teams window is disabled in the extension options');
+      }
+    });
+  }
+  return true;
+};
+
+chrome.runtime.onMessage.addListener(minimizeCurrentWindowListener);


### PR DESCRIPTION
In the Teams PWA, notifications are not shown if:

- the selected chat in Teams is the one that will receive a message
- and the Teams window is in the background but not minimized (when minimized, notifications will come).

This pull request addresses the issue by minimizing the Teams window when it loses focus (document.hasFocus() === false). I also added the extension options to be able to turn on/off this behavior. The window gets minimized only if it contains no other tabs.

I [reported this problem](https://feedbackportal.microsoft.com/feedback/idea/1354a257-28a9-ed11-a81b-002248519701) to Microsoft, but I don't expect it to be resolved anytime soon.