### PR TITLE
Extension options

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,10 +9,14 @@
   },
   "content_scripts": [
     {
-      "js": ["scripts/content.js"],
+      "js": ["scripts/default-options.js", "scripts/content.js"],
       "matches": ["https://teams.microsoft.com/*", "http://localhost/*"]
     }
   ],
+  "permissions": [
+    "storage"
+  ],
+  "options_page": "options/options.html",
   "web_accessible_resources": [
     {
       "resources": [

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Microsoft Teams Notification Sound Extension Options</title>
+
+  <style>
+    body {
+      margin-left: 1rem;
+    }
+    .description {
+      color: gray;
+      font-size: smaller;
+    }
+
+    #saveButton {
+      margin-top: 1rem;
+    }
+
+    .checkbox-option {
+      display: flex;
+      flex-direction: row;
+      align-items: start;
+      font-size: 125%;
+    }
+
+    .checkbox-option:not(:last-child) {
+      margin-bottom: 1rem;
+    }
+
+    .checkbox-option>div:first-child {
+      margin-right: .5rem;
+      padding-top: 2px;
+    }
+
+    #statusMessage {
+      display: inline;
+      margin-top: 1rem;
+      margin-left: 1rem;
+    }
+
+    button {
+      font-size: large;
+      padding: .25em .5em;
+    }
+  </style>
+</head>
+
+<body>
+
+  <h1>Microsoft Teams Notification Sound - options</h1>
+
+  <div class="checkbox-option">
+    <div>
+      <input id="playNotificationSound" type="checkbox" value="1">
+    </div>
+    <div>
+      <label for="playNotificationSound">
+        Play sound when Teams creates a notification
+        <div class="description">Teams PWA doesn't support notification sounds on Linux even if it has such option in its settings. This option fixes it.</div>
+      </label>
+    </div>
+  </div>
+
+  <button id="saveButton">Save</button>
+
+  <div id="statusMessage"></div>
+
+  <script src="../scripts/default-options.js"></script>
+  <script src="options.js"></script>
+</body>
+
+</html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,29 @@
+// Saves options to chrome.storage
+function saveOptions() {
+  const options = {
+    playNotificationSound: document.getElementById('playNotificationSound').checked
+  };
+
+  console.log('Options to be saved', options);
+
+  chrome.storage.sync.set(options, () => {
+    console.log('Options saved');
+    var status = document.getElementById('statusMessage');
+    status.textContent = 'Options saved';
+    setTimeout(() => { status.textContent = '' }, 1000);
+  });
+}
+
+function restoreOptions() {
+  // Use default value for minimizeWindow
+  chrome.storage.sync.get(
+    defaultOptions,
+    options => {
+      console.log('Options from storage or defaults', options);
+      document.getElementById('playNotificationSound').checked = Boolean(options.playNotificationSound);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', restoreOptions);
+document.getElementById('saveButton')
+  .addEventListener('click', saveOptions);

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -1,7 +1,34 @@
-// https://stackoverflow.com/a/9517879
-const s = document.createElement('script');
-s.src = chrome.runtime.getURL('scripts/teams-notification.js');
-s.onload = function () {
-  this.remove();
+const teamsExtension = {
+  options: undefined
+}
+
+const sendOptionsToApplicationWindow = () => {
+  console.debug('Sending extension options to application window', teamsExtension.options);
+  window.postMessage({type : 'teams-extension-options', text: JSON.stringify(teamsExtension.options)}, "*");
+}
+
+const createTeamsNotificationScript = () => {
+  // https://stackoverflow.com/a/9517879
+  const s = document.createElement('script');
+  s.src = chrome.runtime.getURL('scripts/teams-notification.js');
+  s.onload = function () {
+    sendOptionsToApplicationWindow();
+    this.remove();
+  };
+  (document.head || document.documentElement).appendChild(s);
 };
-(document.head || document.documentElement).appendChild(s);
+
+chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
+  teamsExtension.options = optionsFromStorageOrDefaults;
+  console.debug('Teams extension options', teamsExtension.options);
+
+  createTeamsNotificationScript();
+});
+
+chrome.storage.onChanged.addListener((changes) => {
+  console.log('Extension options changed:', changes);
+  chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
+    teamsExtension.options = optionsFromStorageOrDefaults;
+    sendOptionsToApplicationWindow();
+  });
+});

--- a/src/scripts/default-options.js
+++ b/src/scripts/default-options.js
@@ -1,0 +1,3 @@
+const defaultOptions = { 
+  playNotificationSound: true
+};

--- a/src/scripts/teams-notification.js
+++ b/src/scripts/teams-notification.js
@@ -3,8 +3,14 @@ const extensionRoot = currentScriptSrc.split('/').slice(0, -2).join('/');
 const audioUrl = extensionRoot + '/sounds/teams-notification.mp3';
 const audio = new Audio(audioUrl);
 
+const teamsExtension = {
+  options: undefined
+};
+
 function playNotificationSound() {
-  audio.play();
+  if (teamsExtension.options.playNotificationSound) {
+    audio.play();
+  }
 }
 
 function extend(cls) {
@@ -16,4 +22,20 @@ function extend(cls) {
   return new_constructor;
 }
 
-window.Notification = extend(window.Notification);
+window.addEventListener("message", (event) => {
+  // We only accept messages from ourselves
+  if (event.source !== window) {
+    return;
+  }
+
+  if (event.data.type && (event.data.type === "teams-extension-options")) {
+    console.debug("Teams extension options received: " + event.data.text);
+    if (event.data.text) {
+      const options = JSON.parse(event.data.text);
+      if (!teamsExtension.options) {
+        window.Notification = extend(window.Notification);
+      }
+      teamsExtension.options = options;
+    }
+  }
+}, false);


### PR DESCRIPTION
Extension options page with a possibility to turn off notification sound. The `content.js` script has to send options to the `teams-notification.js` script by `window.postMessage()` since there is no `chrome.storage` API in the regular browser application (Teams).