### PR TITLE
Switch to Activity tab on blur

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -62,6 +62,18 @@
     </div>
   </div>
 
+  <div class="checkbox-option">
+    <div>
+      <input id="switchToActivityViewOnBlur" type="checkbox" value="1">
+    </div>
+    <div>
+      <label for="switchToActivityViewOnBlur">
+        Switch to Activity tab when Teams window loses focus
+        <div class="description">Teams PWA doesn't send notifications for the currently selected chat. If you check this option, Teams will switch to the Activity tab whenever you switch to another window.</div>
+      </label>
+    </div>
+  </div>
+
   <button id="saveButton">Save</button>
 
   <div id="statusMessage"></div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,7 +1,8 @@
 // Saves options to chrome.storage
 function saveOptions() {
   const options = {
-    playNotificationSound: document.getElementById('playNotificationSound').checked
+    playNotificationSound: document.getElementById('playNotificationSound').checked,
+    switchToActivityViewOnBlur: document.getElementById('switchToActivityViewOnBlur').checked
   };
 
   console.log('Options to be saved', options);
@@ -21,6 +22,7 @@ function restoreOptions() {
     options => {
       console.log('Options from storage or defaults', options);
       document.getElementById('playNotificationSound').checked = Boolean(options.playNotificationSound);
+      document.getElementById('switchToActivityViewOnBlur').checked = Boolean(options.switchToActivityViewOnBlur);
     });
 }
 

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -1,5 +1,7 @@
 const teamsExtension = {
-  options: undefined
+  options: undefined,
+
+  buttonIdOfTabSelectedBeforeBlur: undefined
 }
 
 const sendOptionsToApplicationWindow = () => {
@@ -18,17 +20,55 @@ const createTeamsNotificationScript = () => {
   (document.head || document.documentElement).appendChild(s);
 };
 
-chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
-  teamsExtension.options = optionsFromStorageOrDefaults;
-  console.debug('Teams extension options', teamsExtension.options);
+const createFocusLostHandler = windowId => () => {
+  console.debug('Focus lost: ' + windowId);
+  if (teamsExtension.options.switchToActivityViewOnBlur) {
+    // This timeout is necessary to be able to focus a Teams window by clicking its notification. Otherwise it just minimizes right away.
+    setTimeout(() => {
+      if (!document.hasFocus()) {
+        // Don't switch to the Activity tab if there is a call is running
+        const hangupButton = top.document.querySelector('iframe.embedded-page-content').contentDocument.getElementById('hangup-button');
+        if (!hangupButton) {
+          teamsExtension.buttonIdOfTabSelectedBeforeBlur = top.document.querySelector('#teams-app-bar > ul button.app-bar-selected')?.id;
+          console.debug('Switching to the Activity tab: ' + windowId);
+          const activityButton = top.document.querySelector('#teams-app-bar > ul > li:first-child > button');
+          if (!activityButton.classList.contains('app-bar-selected')) {
+            activityButton.click();
+          } else {
+            console.debug('Activity tab already selected');
+          }
+        } else {
+          console.debug('There is running call, switching to the Activity tab is suspended');
+        }
+      }
+    }, 10);
+  } else {
+    console.debug('Switching to the Activity tab is disabled in the extension options');
+  }
+};
 
-  createTeamsNotificationScript();
-});
-
-chrome.storage.onChanged.addListener((changes) => {
-  console.log('Extension options changed:', changes);
+window.addEventListener('load', () => {
   chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
     teamsExtension.options = optionsFromStorageOrDefaults;
-    sendOptionsToApplicationWindow();
+    console.debug('Teams extension options', teamsExtension.options);
+
+    console.debug('Adding window blur listener');
+    window.addEventListener('blur', createFocusLostHandler('main-window'));
+
+    // The main window doesn't fire blur event if the focus was in an iframe. So add listeners to iframes as well.
+    document.querySelectorAll('iframe').forEach(docIframe => {
+      console.debug('Adding blur listener for iframe', docIframe.id);
+      docIframe.contentWindow.addEventListener('blur', createFocusLostHandler('iframe#' + docIframe.id));
+    });
+
+    createTeamsNotificationScript();
+  });
+
+  chrome.storage.onChanged.addListener((changes) => {
+    console.log('Extension options changed:', changes);
+    chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
+      teamsExtension.options = optionsFromStorageOrDefaults;
+      sendOptionsToApplicationWindow();
+    });
   });
 });

--- a/src/scripts/default-options.js
+++ b/src/scripts/default-options.js
@@ -1,3 +1,4 @@
 const defaultOptions = { 
-  playNotificationSound: true
+  playNotificationSound: true,
+  switchToActivityViewOnBlur: true
 };


### PR DESCRIPTION
When the Teams PWA window loses focus, the extension switches it to the Activity tab.

It's also possible to create a reverse function - when Teans window is focused, restore the last selected tab. But I'm not sure if it's not too much switching.