### PR TITLE
switch to "new chat" on blur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/*.code-workspace

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -62,6 +62,18 @@
     </div>
   </div>
 
+  <div class="checkbox-option">
+    <div>
+      <input id="switchToNewChatOnBlur" type="checkbox" value="1">
+    </div>
+    <div>
+      <label for="switchToNewChatOnBlur">
+        Switch to New Chat when Teams window loses focus
+        <div class="description">Teams PWA doesn't send notifications for the currently selected chat. If you check this option, Teams will switch to New Chat whenever you switch to another window.</div>
+      </label>
+    </div>
+  </div>
+
   <button id="saveButton">Save</button>
 
   <div id="statusMessage"></div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,7 +1,8 @@
 // Saves options to chrome.storage
 function saveOptions() {
   const options = {
-    playNotificationSound: document.getElementById('playNotificationSound').checked
+    playNotificationSound: document.getElementById('playNotificationSound').checked,
+    switchToNewChatOnBlur: document.getElementById('switchToNewChatOnBlur').checked,
   };
 
   console.log('Options to be saved', options);
@@ -21,6 +22,7 @@ function restoreOptions() {
     options => {
       console.log('Options from storage or defaults', options);
       document.getElementById('playNotificationSound').checked = Boolean(options.playNotificationSound);
+      document.getElementById('switchToNewChatOnBlur').checked = Boolean(options.switchToNewChatOnBlur);
     });
 }
 

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -25,11 +25,12 @@ const createFocusLostHandler = windowId => () => {
     setTimeout(() => {
       if (!document.hasFocus()) {
         // Don't switch to New Chat if there is a call is running
-        const hangupButton = top.document.querySelector('iframe.embedded-page-content').contentDocument.getElementById('hangup-button');
+        const hangupElement = top.document.querySelector('iframe.embedded-page-content');
+        const hangupButton = hangupElement ? hangupElement.contentDocument.getElementById('hangup-button') : null;
         if (!hangupButton) {
-          const buttonNewChat = top.document.querySelector('[title="Nuova chat (Alt+N)"]');
+          const buttonNewChat = top.document.querySelector('[data-tid="lr-create-chat"]');
           if(buttonNewChat){
-            const elemNewChat = document.querySelector('[data-tid="chat-li-entry-with-Nuova chat"]');
+            const elemNewChat = document.querySelector('.cle-new');
             if(elemNewChat){
               console.log('element newChat already present, no need to do nothing');
             } else {

--- a/src/scripts/content.js
+++ b/src/scripts/content.js
@@ -18,17 +18,57 @@ const createTeamsNotificationScript = () => {
   (document.head || document.documentElement).appendChild(s);
 };
 
-chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
-  teamsExtension.options = optionsFromStorageOrDefaults;
-  console.debug('Teams extension options', teamsExtension.options);
+const createFocusLostHandler = windowId => () => {
+  console.debug('Focus lost: ' + windowId);
+  if (teamsExtension.options.switchToNewChatOnBlur) {
+    // This timeout is necessary to be able to focus a Teams window by clicking its notification. Otherwise it just minimizes right away.
+    setTimeout(() => {
+      if (!document.hasFocus()) {
+        // Don't switch to New Chat if there is a call is running
+        const hangupButton = top.document.querySelector('iframe.embedded-page-content').contentDocument.getElementById('hangup-button');
+        if (!hangupButton) {
+          const buttonNewChat = top.document.querySelector('[title="Nuova chat (Alt+N)"]');
+          if(buttonNewChat){
+            const elemNewChat = document.querySelector('[data-tid="chat-li-entry-with-Nuova chat"]');
+            if(elemNewChat){
+              console.log('element newChat already present, no need to do nothing');
+            } else {
+              console.debug('click on buttonNewChat');
+              buttonNewChat.click();
+            }
+          }
+        } else {
+          console.debug('There is running call, switching to New Chat is suspended');
+        }
+      }
+    }, 10);
+  } else {
+    console.debug('Switching to New Chat is disabled in the extension options');
+  }
+};
 
-  createTeamsNotificationScript();
-});
-
-chrome.storage.onChanged.addListener((changes) => {
-  console.log('Extension options changed:', changes);
+window.addEventListener('load', () => {
   chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
     teamsExtension.options = optionsFromStorageOrDefaults;
-    sendOptionsToApplicationWindow();
+    console.debug('Teams extension options', teamsExtension.options);
+
+    console.debug('Adding window blur listener');
+    window.addEventListener('blur', createFocusLostHandler('main-window'));
+
+    // The main window doesn't fire blur event if the focus was in an iframe. So add listeners to iframes as well.
+    document.querySelectorAll('iframe').forEach(docIframe => {
+      console.debug('Adding blur listener for iframe', docIframe.id);
+      docIframe.contentWindow.addEventListener('blur', createFocusLostHandler('iframe#' + docIframe.id));
+    });
+
+    createTeamsNotificationScript();
+  });
+
+  chrome.storage.onChanged.addListener((changes) => {
+    console.log('Extension options changed:', changes);
+    chrome.storage.sync.get(defaultOptions, optionsFromStorageOrDefaults => {
+      teamsExtension.options = optionsFromStorageOrDefaults;
+      sendOptionsToApplicationWindow();
+    });
   });
 });

--- a/src/scripts/default-options.js
+++ b/src/scripts/default-options.js
@@ -1,3 +1,4 @@
 const defaultOptions = { 
-  playNotificationSound: true
+  playNotificationSound: true,
+  switchToNewChatOnBlur: true,
 };


### PR DESCRIPTION
@simgunz : here is the code I'm using that switch to "new chat" when Teams PWA window loses focus. It is completely based on work of @janhalasa (in his fork).
It is still not ideal, because whenever you change focus on another windows, even if the Teams window is visible (and maybe you are activevely reading its content), the "new chat" view is activated and you loose the content of the current chat.
But at least it seems to provide notification.
Hopefully Microsoft will improve the Teams PWA, never had so many issues with old retired native app.